### PR TITLE
fix(interpreter): should keep ReturnValue when if expr has a return stmt

### DIFF
--- a/interpreter/src/eval/mod.rs
+++ b/interpreter/src/eval/mod.rs
@@ -17,16 +17,10 @@ impl Evaluator {
   }
 
   pub fn eval(&self, stmts: Vec<ast::Statement<'_>>) -> Option<Object> {
-    let mut result: Option<Object> = None;
-    for stmt in stmts {
-      match self.eval_stmt(stmt)? {
-        Object::ReturnValue(val) => return Some(*val), // unwrap value in ReturnValue
-        Object::Error(message) => return Some(Object::Error(message)),
-        // always use the last evaluation as the final answer
-        object => result = Some(object),
-      }
-    }
-    result
+    self.eval_block_stmt(stmts).map(|result| match result {
+      Object::ReturnValue(val) => *val, // unwrap value for better DX
+      _ => result,
+    })
   }
 
   fn eval_stmt(&self, stmt: ast::Statement<'_>) -> Option<Object> {
@@ -48,7 +42,7 @@ impl Evaluator {
     let mut result: Option<Object> = None;
     for stmt in block_stmts {
       match self.eval_stmt(stmt)? {
-        Object::ReturnValue(val) => return Some(Object::ReturnValue(val)), // different from `eval` method
+        Object::ReturnValue(val) => return Some(Object::ReturnValue(val)),
         Object::Error(error) => return Some(Object::Error(error)),
         obj => result = Some(obj),
       }

--- a/interpreter/src/eval/test.rs
+++ b/interpreter/src/eval/test.rs
@@ -112,10 +112,10 @@ fn eval_if_else_expr() {
 #[test]
 fn eval_return_stmt() {
   let cases = vec![
-    // ("return 1;", 1),
-    // ("return 1; 2;", 1),
-    // ("return 6 * 7; 8", 42),
-    // ("99; return 7 * 8; 9;", 56),
+    ("return 1;", 1),
+    ("return 1; 2;", 1),
+    ("return 6 * 7; 8", 42),
+    ("99; return 7 * 8; 9;", 56),
     (
       "if (10 > 1) {
       if (10 > 1) {

--- a/interpreter/src/eval/test.rs
+++ b/interpreter/src/eval/test.rs
@@ -112,10 +112,19 @@ fn eval_if_else_expr() {
 #[test]
 fn eval_return_stmt() {
   let cases = vec![
-    ("return 1;", 1),
-    ("return 1; 2;", 1),
-    ("return 6 * 7; 8", 42),
-    ("99; return 7 * 8; 9;", 56),
+    // ("return 1;", 1),
+    // ("return 1; 2;", 1),
+    // ("return 6 * 7; 8", 42),
+    // ("99; return 7 * 8; 9;", 56),
+    (
+      "if (10 > 1) {
+      if (10 > 1) {
+        return 10;
+      }
+      return 1;
+    }",
+      10,
+    ),
   ];
 
   for (input, expected) in cases {


### PR DESCRIPTION
```
if (10 > 1) {
  if (10 > 1) {
    return 10;
  } // nest block should return `Object::ReturnValue(Box::new(Object::Int(10)))` instead of `Object::Int(10)`
  // once we encounter ReturnValue, outer block should stop the execution
  return 1;
} // outer block should return Object::Int(10) that is wrapped by Object::ReturnValue, instead of Object::ReturnValue
```